### PR TITLE
Fix links to the GitHub repo

### DIFF
--- a/packages/p5-kernel-extension/package.json
+++ b/packages/p5-kernel-extension/package.json
@@ -2,13 +2,13 @@
   "name": "@jupyterlite/p5-kernel-extension",
   "version": "0.1.0-alpha.10",
   "description": "JupyterLite - p5.js Kernel Extension",
-  "homepage": "https://github.com/jupyterlite/jupyterlite",
+  "homepage": "https://github.com/jupyterlite/p5-kernel",
   "bugs": {
-    "url": "https://github.com/jupyterlite/jupyterlite/issues"
+    "url": "https://github.com/jupyterlite/p5-kernel/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlite/jupyterlite.git"
+    "url": "https://github.com/jupyterlite/p5-kernel.git"
   },
   "license": "BSD-3-Clause",
   "author": {

--- a/packages/p5-kernel/package.json
+++ b/packages/p5-kernel/package.json
@@ -2,13 +2,13 @@
   "name": "@jupyterlite/p5-kernel",
   "version": "0.1.0-alpha.10",
   "description": "JupyterLite - p5.js Kernel",
-  "homepage": "https://github.com/jupyterlite/jupyterlite",
+  "homepage": "https://github.com/jupyterlite/p5-kernel",
   "bugs": {
-    "url": "https://github.com/jupyterlite/jupyterlite/issues"
+    "url": "https://github.com/jupyterlite/p5-kernel/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlite/jupyterlite.git"
+    "url": "https://github.com/jupyterlite/p5-kernel.git"
   },
   "license": "BSD-3-Clause",
   "author": {

--- a/packages/p5-kernel/src/kernel.ts
+++ b/packages/p5-kernel/src/kernel.ts
@@ -68,7 +68,7 @@ export class P5Kernel extends JavaScriptKernel implements IKernel {
       help_links: [
         {
           text: 'p5.js Kernel',
-          url: 'https://github.com/jupyterlite/jupyterlite'
+          url: 'https://github.com/jupyterlite/p5-kernel'
         }
       ]
     };


### PR DESCRIPTION
So they point to this new repo from the PyPI page.

Fixes #3 