### PR TITLE
Automated Changelog Entry for 0.1.0a11 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.1.0a11
+
+([Full Changelog](https://github.com/jupyterlite/p5-kernel/compare/@jupyterlite/p5-kernel-extension@0.1.0-alpha.10...16bed8258f82806a188f070ee8024b16228dfdd4))
+
+### Maintenance and upkeep improvements
+
+- Fix links to the GitHub repo [#5](https://github.com/jupyterlite/p5-kernel/pull/5) ([@jtpio](https://github.com/jtpio))
+- Use consistent naming for the lab extension [#4](https://github.com/jupyterlite/p5-kernel/pull/4) ([@jtpio](https://github.com/jtpio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlite/p5-kernel/graphs/contributors?from=2021-09-30&to=2021-10-01&type=c))
+
+[@jtpio](https://github.com/search?q=repo%3Ajupyterlite%2Fp5-kernel+involves%3Ajtpio+updated%3A2021-09-30..2021-10-01&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.1.0a10
 
 ([Full Changelog](https://github.com/jupyterlite/p5-kernel/compare/first-commit...b91d19f351a4e130a446bb45e0715d29aca24666))
@@ -15,8 +32,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyterlite/p5-kernel/graphs/contributors?from=2021-09-29&to=2021-09-30&type=c))
 
 [@bollwyvl](https://github.com/search?q=repo%3Ajupyterlite%2Fp5-kernel+involves%3Abollwyvl+updated%3A2021-09-29..2021-09-30&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlite%2Fp5-kernel+involves%3Ajtpio+updated%3A2021-09-29..2021-09-30&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.0.1
 


### PR DESCRIPTION
Automated Changelog Entry for 0.1.0a11 on main
Python version: 0.1.0a11
npm version: @jupyterlite/p5-kernel-root: 0.1.0
npm workspace versions:
@jupyterlite/p5-kernel-extension: 0.1.0-alpha.11
@jupyterlite/p5-kernel: 0.1.0-alpha.11

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlite/p5-kernel  |
| Branch  | main  |
| Version Spec | 0.1.0-alpha.11 |
| Since | @jupyterlite/p5-kernel-extension@0.1.0-alpha.10 |