### PR TITLE
Fix handling of the logo

### DIFF
--- a/packages/p5-kernel-extension/src/index.ts
+++ b/packages/p5-kernel-extension/src/index.ts
@@ -31,7 +31,6 @@ const kernel: JupyterLiteServerPlugin<void> = {
     const p5Url = URLExt.isLocal(url)
       ? URLExt.join(window.location.origin, url)
       : url;
-    const logo = new URL(p5Logo);
     kernelspecs.register({
       spec: {
         name: 'p5js',
@@ -48,7 +47,7 @@ const kernel: JupyterLiteServerPlugin<void> = {
         },
         resources: {
           'logo-32x32': 'TODO',
-          'logo-64x64': logo.pathname
+          'logo-64x64': p5Logo
         }
       },
       create: async (options: IKernel.IOptions): Promise<IKernel> => {


### PR DESCRIPTION
Pass the correct URL to fetch the kernelspec logo.

Depends on https://github.com/jupyterlite/jupyterlite/pull/371