### PR TITLE
Update P5.js to version 1.4.2

### DIFF
--- a/packages/p5-kernel-extension/src/index.ts
+++ b/packages/p5-kernel-extension/src/index.ts
@@ -17,7 +17,7 @@ import p5Logo from '../style/icons/p5js.png';
 /**
  * The default CDN fallback for p5.js
  */
-const P5_CDN_URL = 'https://cdn.jsdelivr.net/npm/p5@1.3.1/lib/p5.js';
+const P5_CDN_URL = 'https://cdn.jsdelivr.net/npm/p5@1.4.2/lib/p5.js';
 
 /**
  * A plugin to register the p5.js kernel.


### PR DESCRIPTION
Update P5.js to version 1.4.2 from https://cdn.jsdelivr.net/npm/p5@1.4.2/lib/p5.js

This may help close https://github.com/jupyterlite/p5-kernel/issues/14
I've not worked on Jupyter kernels before, so this maybe missing elements.